### PR TITLE
Introduce Errorlog

### DIFF
--- a/.java-format.json
+++ b/.java-format.json
@@ -4,6 +4,13 @@
     "space_around_operators": true,
     "max_line_length": 100,
     "class_modifier_order": ["public", "abstract", "final"],
-    "method_modifier_order": ["public", "static", "final"]
+    "method_modifier_order": ["public", "static", "final"],
+    "naming_conventions": {
+        "class": "PascalCase",
+        "method": "camelCase",
+        "variable": "camelCase",
+        "parameter": "camelCase",
+        "constant": "UPPER_CASE"
+    }
 }
 

--- a/.java-format.json
+++ b/.java-format.json
@@ -6,11 +6,11 @@
     "class_modifier_order": ["public", "abstract", "final"],
     "method_modifier_order": ["public", "static", "final"],
     "naming_conventions": {
-        "class": "PascalCase",
-        "method": "camelCase",
-        "variable": "camelCase",
-        "parameter": "camelCase",
-        "constant": "UPPER_CASE"
+        "class": "[A-Z][a-zA-Z0-9]*",
+        "method": "camelcase",
+        "variable": "[a-z][a-zA-Z0-9]*",
+        "parameter": "camelcase",
+        "constant": "uppercase"
     }
 }
 

--- a/ErrorLogger.py
+++ b/ErrorLogger.py
@@ -1,0 +1,81 @@
+from JavaParser import JavaParser
+from JavaParserVisitor import JavaParserVisitor
+from StandardNamingConventions import StandardNamingConventions
+import re
+
+class ErrorLogger(JavaParserVisitor):
+    def __init__(self, naming_convention_configs):
+        self.naming_convention_configs = naming_convention_configs
+        self.error_log = []
+
+    def visitClassDeclaration(self, ctx: JavaParser.ClassDeclarationContext):
+        class_name = ctx.identifier().getText()
+        
+        if "class" in self.naming_convention_configs:
+            class_config = self.naming_convention_configs["class"]
+
+            if StandardNamingConventions.PASCAL_CASE.value in class_config and not self._is_pascal_case(class_name):
+                self.error_log.append(f"Class name {class_name} should be in PascalCase")
+        
+        return self.visitChildren(ctx)
+    
+    def visitMethodDeclaration(self, ctx: JavaParser.MethodDeclarationContext):
+        method_name = ctx.identifier().getText()
+        
+        if "method" in self.naming_convention_configs:
+            method_config = self.naming_convention_configs["method"]
+
+            if StandardNamingConventions.CAMEL_CASE.value in method_config and not self._is_camel_case(method_name):
+                self.error_log.append(f"Method name {method_name} should be in camelCase")
+
+        return self.visitChildren(ctx)
+    
+    def visitFieldDeclaration(self, ctx: JavaParser.FieldDeclarationContext):
+        declarators = ctx.variableDeclarators()
+        modifiers = [mod.getText() for mod in ctx.parentCtx.parentCtx.modifier()]
+        is_final = "final" in modifiers
+        is_static = "static" in modifiers
+
+        if "variable" in self.naming_convention_configs:
+            variable_config = self.naming_convention_configs["variable"]
+        
+        if "constant" in self.naming_convention_configs:
+            constant_config = self.naming_convention_configs["constant"]
+
+        for declarator in declarators.variableDeclarator():
+            variable_name = declarator.variableDeclaratorId().getText()
+            if is_final and is_static:
+                if StandardNamingConventions.UPPER_CASE.value in constant_config and not self._is_upper_case(variable_name):
+                    self.error_log.append(f"Static final variable name {variable_name} should be in UPPER_CASE")
+            else:
+                if StandardNamingConventions.CAMEL_CASE.value in variable_config and not self._is_camel_case(variable_name):
+                    self.error_log.append(f"Variable name {variable_name} should be in camelCase")
+    
+        return self.visitChildren(ctx)
+    
+    def visitLocalVariableDeclaration(self, ctx: JavaParser.LocalVariableDeclarationContext):
+        declarators = ctx.variableDeclarators()
+
+        for declarator in declarators.variableDeclarator():
+            variable_name = declarator.variableDeclaratorId().getText()
+            if "variable" in self.naming_convention_configs:
+                variable_config = self.naming_convention_configs["variable"]
+                if StandardNamingConventions.CAMEL_CASE.value in variable_config and not self._is_camel_case(variable_name):
+                    self.error_log.append(f"Variable name {variable_name} should be in camelCase")
+                    
+        return self.visitChildren(ctx)
+        
+
+    def _is_pascal_case(self, name):
+        return bool(re.fullmatch(r"[A-Z][a-zA-Z0-9]*", name))
+
+    def _is_camel_case(self, name):
+        return bool(re.fullmatch(r"[a-z][a-zA-Z0-9]*", name))
+    
+    def _is_upper_case(self, name):
+        return bool(re.fullmatch(r"[A-Z][A-Z0-9_]*", name))
+
+    def find_errors(self, tree):
+        self.error_log = []
+        self.visit(tree)
+        return self.error_log

--- a/ErrorLogger.py
+++ b/ErrorLogger.py
@@ -14,7 +14,7 @@ class ErrorLogger(JavaParserVisitor):
         if "class" in self.naming_convention_configs:
             class_config = self.naming_convention_configs["class"]
 
-        error = self.check_convention(class_name, class_config, class_config)
+        error = self.check_convention(class_name, class_config)
         if error:
             self.error_log.append("Class name " + error)
         
@@ -26,7 +26,7 @@ class ErrorLogger(JavaParserVisitor):
         if "method" in self.naming_convention_configs:
             method_config = self.naming_convention_configs["method"]
 
-        error = self.check_convention(method_name, method_config, method_config)
+        error = self.check_convention(method_name, method_config)
         if error:
             self.error_log.append("Method name " + error)
         
@@ -45,13 +45,13 @@ class ErrorLogger(JavaParserVisitor):
             constant_config = self.naming_convention_configs["constant"]
         
         for declarator in declarators.variableDeclarator():
-            variable_name = declarator.variableDeclaratorId().getText()
+            field_name = declarator.variableDeclaratorId().getText()
             error = None
             
             if is_static and is_final:
-                error = self.check_convention(variable_name, constant_config, constant_config)
+                error = self.check_convention(field_name, constant_config)
             else:
-                error = self.check_convention(variable_name, variable_config, variable_config)
+                error = self.check_convention(field_name, variable_config)
 
             if error:
                 self.error_log.append("Field name " + error)
@@ -66,7 +66,7 @@ class ErrorLogger(JavaParserVisitor):
 
         for declarator in declarators.variableDeclarator():
             variable_name = declarator.variableDeclaratorId().getText()
-            error = self.check_convention(variable_name, variable_config, variable_config)
+            error = self.check_convention(variable_name, variable_config)
             if error:
                 self.error_log.append("Local variable name " + error)
         
@@ -78,21 +78,21 @@ class ErrorLogger(JavaParserVisitor):
         if "parameter" in self.naming_convention_configs:
             parameter_config = self.naming_convention_configs["parameter"]
 
-        error = self.check_convention(parameter_name, parameter_config, parameter_config)
+        error = self.check_convention(parameter_name, parameter_config)
         if error:
             self.error_log.append("Parameter name " + error)
         
         return self.visitChildren(ctx)
 
     @staticmethod
-    def check_convention(name, convention, regex=None) -> bool:
+    def check_convention(name, convention) -> bool:
         patterns = {
             StandardNamingConventions.PASCAL_CASE.value: r"[A-Z][a-zA-Z0-9]*",
             StandardNamingConventions.CAMEL_CASE.value: r"[a-z][a-zA-Z0-9]*",
             StandardNamingConventions.UPPER_CASE.value: r"[A-Z][A-Z0-9_]*"
         }
 
-        pattern = patterns.get(convention, regex)
+        pattern = patterns.get(convention, convention)
 
         if not bool(re.fullmatch(pattern, name)):
             return f"'{name}' does not match the naming convention '{convention}'"

--- a/ErrorLogger.py
+++ b/ErrorLogger.py
@@ -14,68 +14,92 @@ class ErrorLogger(JavaParserVisitor):
         if "class" in self.naming_convention_configs:
             class_config = self.naming_convention_configs["class"]
 
-            if StandardNamingConventions.PASCAL_CASE.value in class_config and not self._is_pascal_case(class_name):
-                self.error_log.append(f"Class name {class_name} should be in PascalCase")
+        error = self.check_convention(class_name, class_config, class_config)
+        if error:
+            self.error_log.append("Class name " + error)
         
         return self.visitChildren(ctx)
-    
+
     def visitMethodDeclaration(self, ctx: JavaParser.MethodDeclarationContext):
         method_name = ctx.identifier().getText()
         
         if "method" in self.naming_convention_configs:
             method_config = self.naming_convention_configs["method"]
 
-            if StandardNamingConventions.CAMEL_CASE.value in method_config and not self._is_camel_case(method_name):
-                self.error_log.append(f"Method name {method_name} should be in camelCase")
-
+        error = self.check_convention(method_name, method_config, method_config)
+        if error:
+            self.error_log.append("Method name " + error)
+        
         return self.visitChildren(ctx)
-    
+
     def visitFieldDeclaration(self, ctx: JavaParser.FieldDeclarationContext):
         declarators = ctx.variableDeclarators()
         modifiers = [mod.getText() for mod in ctx.parentCtx.parentCtx.modifier()]
-        is_final = "final" in modifiers
         is_static = "static" in modifiers
+        is_final = "final" in modifiers
 
         if "variable" in self.naming_convention_configs:
             variable_config = self.naming_convention_configs["variable"]
-        
+
         if "constant" in self.naming_convention_configs:
             constant_config = self.naming_convention_configs["constant"]
-
+        
         for declarator in declarators.variableDeclarator():
             variable_name = declarator.variableDeclaratorId().getText()
-            if is_final and is_static:
-                if StandardNamingConventions.UPPER_CASE.value in constant_config and not self._is_upper_case(variable_name):
-                    self.error_log.append(f"Static final variable name {variable_name} should be in UPPER_CASE")
+            error = None
+            
+            if is_static and is_final:
+                error = self.check_convention(variable_name, constant_config, constant_config)
             else:
-                if StandardNamingConventions.CAMEL_CASE.value in variable_config and not self._is_camel_case(variable_name):
-                    self.error_log.append(f"Variable name {variable_name} should be in camelCase")
-    
+                error = self.check_convention(variable_name, variable_config, variable_config)
+
+            if error:
+                self.error_log.append("Field name " + error)
+        
         return self.visitChildren(ctx)
     
     def visitLocalVariableDeclaration(self, ctx: JavaParser.LocalVariableDeclarationContext):
         declarators = ctx.variableDeclarators()
 
+        if "variable" in self.naming_convention_configs:
+            variable_config = self.naming_convention_configs["variable"]
+
         for declarator in declarators.variableDeclarator():
             variable_name = declarator.variableDeclaratorId().getText()
-            if "variable" in self.naming_convention_configs:
-                variable_config = self.naming_convention_configs["variable"]
-                if StandardNamingConventions.CAMEL_CASE.value in variable_config and not self._is_camel_case(variable_name):
-                    self.error_log.append(f"Variable name {variable_name} should be in camelCase")
-                    
-        return self.visitChildren(ctx)
+            error = self.check_convention(variable_name, variable_config, variable_config)
+            if error:
+                self.error_log.append("Local variable name " + error)
         
+        return self.visitChildren(ctx)
 
-    def _is_pascal_case(self, name):
-        return bool(re.fullmatch(r"[A-Z][a-zA-Z0-9]*", name))
+    def visitFormalParameter(self, ctx: JavaParser.FormalParameterContext):
+        parameter_name = ctx.variableDeclaratorId().getText()
+        
+        if "parameter" in self.naming_convention_configs:
+            parameter_config = self.naming_convention_configs["parameter"]
 
-    def _is_camel_case(self, name):
-        return bool(re.fullmatch(r"[a-z][a-zA-Z0-9]*", name))
-    
-    def _is_upper_case(self, name):
-        return bool(re.fullmatch(r"[A-Z][A-Z0-9_]*", name))
+        error = self.check_convention(parameter_name, parameter_config, parameter_config)
+        if error:
+            self.error_log.append("Parameter name " + error)
+        
+        return self.visitChildren(ctx)
 
-    def find_errors(self, tree):
+    @staticmethod
+    def check_convention(name, convention, regex=None) -> bool:
+        patterns = {
+            StandardNamingConventions.PASCAL_CASE.value: r"[A-Z][a-zA-Z0-9]*",
+            StandardNamingConventions.CAMEL_CASE.value: r"[a-z][a-zA-Z0-9]*",
+            StandardNamingConventions.UPPER_CASE.value: r"[A-Z][A-Z0-9_]*"
+        }
+
+        pattern = patterns.get(convention, regex)
+
+        if not bool(re.fullmatch(pattern, name)):
+            return f"'{name}' does not match the naming convention '{convention}'"
+        
+        return None
+
+    def find_errors(self, tree) -> list:
         self.error_log = []
         self.visit(tree)
         return self.error_log

--- a/StandardNamingConventions.py
+++ b/StandardNamingConventions.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class StandardNamingConventions(Enum):
+    PASCAL_CASE = "PascalCase"
+    CAMEL_CASE = "camelCase"
+    UPPER_CASE = "UPPER_CASE"

--- a/StandardNamingConventions.py
+++ b/StandardNamingConventions.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
 class StandardNamingConventions(Enum):
-    PASCAL_CASE = "PascalCase"
-    CAMEL_CASE = "camelCase"
-    UPPER_CASE = "UPPER_CASE"
+    PASCAL_CASE = "pascalcase"
+    CAMEL_CASE = "camelcase"
+    UPPER_CASE = "uppercase"

--- a/test.java
+++ b/test.java
@@ -1,7 +1,9 @@
 public class HelloWorld{
-    public static void main(String[] args) {System.out.println("Hello World");int a = 10;}
-    public void test(){System.out.println("Hello World");}
-    public void test2()
+    private int AA = 10;
+    public final static int bb = 10;
+    public static void main(String[] args) {System.out.println("Hello World"); int c = 10;}
+    public void Test(){System.out.println("Hello World");}
+    public void Test2()
     {
         if (true)
         {

--- a/test.java
+++ b/test.java
@@ -3,7 +3,7 @@ public class HelloWorld{
     public final static int bb = 10;
     public static void main(String[] args) {System.out.println("Hello World"); int c = 10;}
     public void Test(){System.out.println("Hello World");}
-    public void Test2()
+    public void Test2(int x, int Z)
     {
         if (true)
         {

--- a/testmain.py
+++ b/testmain.py
@@ -2,6 +2,7 @@ from antlr4 import *
 from JavaLexer import JavaLexer
 from JavaParser import JavaParser
 from FormattingVisitor import FormattingVisitor
+from ErrorLogger import ErrorLogger
 import json
 
 def load_config(config_path):
@@ -22,8 +23,15 @@ def parse_java_code(file_path):
 
     return tree, tokens
 
-tree, tokens = parse_java_code("Test.java")
+tree, tokens = parse_java_code("test.java")
 config = load_config(".java-format.json")
 
 formatter = FormattingVisitor(tokens, config)
-print(formatter.get_formatted_code(tree))
+
+naming_convention_configs = config.get("naming_conventions", {})
+
+errorvisitor = ErrorLogger(naming_convention_configs)
+errors = errorvisitor.find_errors(tree)
+if errors:
+    for error in errors:
+        print(error)


### PR DESCRIPTION
This pull request introduces several significant changes to enforce naming conventions in Java code and updates the relevant files to support this new functionality. The most important changes include adding naming conventions to the configuration file, implementing a new `ErrorLogger` class to check for naming convention violations, and updating the test and main scripts to utilize this new functionality.

### Configuration Updates:
* [`.java-format.json`](diffhunk://#diff-da92ad726f052e2a22ead6184520136e374352f3ad7efea4a0d987a6ecaf2942L7-R14): Added naming conventions for classes, methods, variables, parameters, and constants.

### New Functionality:
* [`ErrorLogger.py`](diffhunk://#diff-474af3304b708d2b99f385d82c25a9024eaba909158a71eb76c454efde073406R1-R81): Implemented the `ErrorLogger` class to check Java code for naming convention violations using the provided configuration.
* [`StandardNamingConventions.py`](diffhunk://#diff-c407d13c763b89f91c24eeb7acbd8b20da93d3318f3d1b6d94297cb1596460f8R1-R6): Added an enumeration for standard naming conventions, including PascalCase, camelCase, and UPPER_CASE.

### Test and Main Script Updates:
* [`test.java`](diffhunk://#diff-37caa6f7d8a4605679fb3bfbfd5c0a312e895037c606d05f2fdd6c57592e1386L2-R6): Modified the test Java file to include naming convention violations for testing purposes.
* [`testmain.py`](diffhunk://#diff-2298f6f12e6352a7975afb5eda810fbe673ad570aeb9101a85940472052c0eccR5): Updated the main script to integrate the `ErrorLogger` and print any naming convention errors found in the Java code. [[1]](diffhunk://#diff-2298f6f12e6352a7975afb5eda810fbe673ad570aeb9101a85940472052c0eccR5) [[2]](diffhunk://#diff-2298f6f12e6352a7975afb5eda810fbe673ad570aeb9101a85940472052c0eccL25-R37)…nor adjustments in the java file.

**Just to note, this is the base that handles the Java standards only. I'm looking forward for ideas and suggestions on how to approach the planned regex usage.** #3 