### PR TITLE
Initial extra config types (indent types and import settings)

### DIFF
--- a/.java-format.json
+++ b/.java-format.json
@@ -12,6 +12,9 @@
         "variable": "[a-z][a-zA-Z0-9]*",
         "parameter": "camelcase",
         "constant": "uppercase"
+    },
+    "imports": {
+        "order": "sort",
+        "merge": true
     }
 }
-

--- a/.java-format.json
+++ b/.java-format.json
@@ -2,6 +2,7 @@
     "indent_size": 4,
     "brace_style": "break",  
     "space_around_operators": true,
+    "indentation_type": "spaces",
     "max_line_length": 100,
     "class_modifier_order": ["public", "abstract", "final"],
     "method_modifier_order": ["public", "static", "final"],

--- a/ConfigClass.py
+++ b/ConfigClass.py
@@ -23,6 +23,10 @@ class ConfigClass:
             'parameter': 'camelcase',
             'constant': 'uppercase'
         }
+        self.imports = {
+            'order': 'preserve',
+            'merge': False
+        }
 
     def read_config(self):
         config_json = {}
@@ -45,6 +49,7 @@ class ConfigClass:
         self.class_modifier_order = config_json.get('class_modifier_order', self.class_modifier_order)
         self.method_modifier_order = config_json.get('method_modifier_order', self.method_modifier_order)
         self.naming_conventions = config_json.get('naming_conventions', self.naming_conventions)
+        self.imports = config_json.get('imports', self.imports)
 
     # Kept for future use
     def save_config(self):

--- a/ConfigClass.py
+++ b/ConfigClass.py
@@ -12,6 +12,7 @@ class ConfigClass:
         self.indent_size = 4
         self.brace_style = 'break'
         self.space_around_operator = True
+        self.indentation_type = 'spaces'
         self.max_line_length = 100
         self.class_modifier_order = ['public', 'abstract', 'final']
         self.method_modifier_order = ['public', 'static', 'final']
@@ -39,6 +40,7 @@ class ConfigClass:
         self.indent_size = config_json.get('indent_size', self.indent_size)
         self.brace_style = config_json.get('brace_style', self.brace_style)
         self.space_around_operator = config_json.get('space_around_operator', self.space_around_operator)
+        self.indentation_type = config_json.get('indentation_type', self.indentation_type)
         self.max_line_length = config_json.get('max_line_length', self.max_line_length)
         self.class_modifier_order = config_json.get('class_modifier_order', self.class_modifier_order)
         self.method_modifier_order = config_json.get('method_modifier_order', self.method_modifier_order)

--- a/FormattingVisitor.py
+++ b/FormattingVisitor.py
@@ -142,7 +142,11 @@ class FormattingVisitor(JavaParserVisitor):
         return sorted(modifiers, key=lambda x: order.index(x) if x in order else len(order))
     
     def _get_indent(self):
-        return " " * (self.indent_level * self.config.indent_size)
+        match self.config.indentation_type:
+            case "spaces":
+                return " " * (self.indent_level * self.config.indent_size)
+            case "tabs":
+                return "\t" * self.indent_level
     
     def get_formatted_code(self, tree):
         self.visit(tree)

--- a/test.java
+++ b/test.java
@@ -1,7 +1,8 @@
+import java.text.ParseException;import java.io.*;import java.text.SimpleDateFormat;import java.util.*;
+
 public class HelloWorld{
     public static void main(String[] args) {System.out.println("Hello World");int a = 10;for(int i=0;i<10;i++) {System.out.println(i);} while(a>0){a--;}do{a++;}while(a<10);}
     public void test(){System.out.println("Hello World");try{int x=1/0;}catch(Exception e){System.out.println(e.getMessage());}}
     public void test2() { if (true) {System.out.println("Hello World"); } else { System.out.println("Hello World"); } switch(a){case 1:{System.out.println("One");break;}default:System.out.println("Other");}}
     public void nestedLoops(){for(int i=0;i<5;i++){for(int j=0;j<5;j++){System.out.println(i*j);}}}
 }
-


### PR DESCRIPTION
This pull request includes updates to the Java formatting configuration and enhancements to the `ConfigClass` and `FormattingVisitor` classes to support new formatting options. The most important changes include adding support for **indentation type** and **import order/merge settings**.

### Configuration updates:

* [`.java-format.json`](diffhunk://#diff-da92ad726f052e2a22ead6184520136e374352f3ad7efea4a0d987a6ecaf2942R5): Added `indentation_type` and `imports` settings to the configuration file to support new formatting options. [[1]](diffhunk://#diff-da92ad726f052e2a22ead6184520136e374352f3ad7efea4a0d987a6ecaf2942R5) [[2]](diffhunk://#diff-da92ad726f052e2a22ead6184520136e374352f3ad7efea4a0d987a6ecaf2942R15-L16)

### Code updates:

* [`ConfigClass.py`](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9R15): Updated the `default_config` and `read_config` methods to include the new `indentation_type` and `imports` settings. [[1]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9R15) [[2]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9R26-R29) [[3]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9R47-R52)

### New functionality in `FormattingVisitor.py`:

* [`FormattingVisitor.py`](diffhunk://#diff-bc83f4e09af6532ae36b35f0cb0f48524a2ca1a17548a6c105edee6f065ce70fR12-R45): Added methods to handle import declarations, including merging and sorting imports, and updated the indentation logic to support both spaces and tabs. [[1]](diffhunk://#diff-bc83f4e09af6532ae36b35f0cb0f48524a2ca1a17548a6c105edee6f065ce70fR12-R45) [[2]](diffhunk://#diff-bc83f4e09af6532ae36b35f0cb0f48524a2ca1a17548a6c105edee6f065ce70fR179-R196)

### Test updates:

* [`test.java`](diffhunk://#diff-37caa6f7d8a4605679fb3bfbfd5c0a312e895037c606d05f2fdd6c57592e1386R1-L7): Added a test case to verify the correct handling of import statements.