### PR TITLE
feat(formatting): toggle indent case labels + indent config segment

### DIFF
--- a/.java-format.json
+++ b/.java-format.json
@@ -1,8 +1,6 @@
 {
-    "indent_size": 4,
     "brace_style": "break",  
     "space_around_operators": true,
-    "indentation_type": "tabs",
     "max_line_length": 100,
     "class_modifier_order": ["public", "abstract", "final"],
     "method_modifier_order": ["public", "static", "final"],
@@ -16,5 +14,10 @@
     "imports": {
         "order": "sort",
         "merge": true
+    },
+    "indents": {
+        "size": 4,
+        "type": "tabs",
+        "switch_case_labels": "indent"
     }
 }

--- a/ConfigClass.py
+++ b/ConfigClass.py
@@ -9,10 +9,8 @@ class ConfigClass:
         self.read_config()
 
     def default_config(self):
-        self.indent_size = 4
         self.brace_style = 'break'
         self.space_around_operator = True
-        self.indentation_type = 'spaces'
         self.max_line_length = 100
         self.class_modifier_order = ['public', 'abstract', 'final']
         self.method_modifier_order = ['public', 'static', 'final']
@@ -24,8 +22,13 @@ class ConfigClass:
             'constant': 'uppercase'
         }
         self.imports = {
-            'order': 'preserve',
+            'order': 'preserve', # 'preserve' or 'sort'
             'merge': False
+        }
+        self.indents = {
+            'size': 4,
+            'type': 'spaces', # 'spaces' or 'tabs'
+            'switch_case_labels': 'indent', # 'indent' or 'no_indent'
         }
 
     def read_config(self):
@@ -41,15 +44,14 @@ class ConfigClass:
             exit(1)
 
         
-        self.indent_size = config_json.get('indent_size', self.indent_size)
         self.brace_style = config_json.get('brace_style', self.brace_style)
         self.space_around_operator = config_json.get('space_around_operator', self.space_around_operator)
-        self.indentation_type = config_json.get('indentation_type', self.indentation_type)
         self.max_line_length = config_json.get('max_line_length', self.max_line_length)
         self.class_modifier_order = config_json.get('class_modifier_order', self.class_modifier_order)
         self.method_modifier_order = config_json.get('method_modifier_order', self.method_modifier_order)
         self.naming_conventions = config_json.get('naming_conventions', self.naming_conventions)
         self.imports = config_json.get('imports', self.imports)
+        self.indents = config_json.get('indents', self.indents)
 
     # Kept for future use
     def save_config(self):
@@ -60,7 +62,9 @@ class ConfigClass:
             'max_line_length': self.max_line_length,
             'class_modifier_order': self.class_modifier_order,
             'method_modifier_order': self.method_modifier_order,
-            'naming_conventions': self.naming_conventions
+            'naming_conventions': self.naming_conventions,
+            'imports': self.imports,
+            'indents': self.indents
         }
 
         with open(self.config_path, 'w') as f:

--- a/FormattingVisitor.py
+++ b/FormattingVisitor.py
@@ -190,11 +190,15 @@ class FormattingVisitor(JavaParserVisitor):
         """Decorator to automatically increase and decrease indentation."""
         @wraps(method)
         def wrapper(self, ctx):
-            self.indent_level += 1
+            ignore_switch_case = method.__name__ == "visitSwitchBlockStatementGroup" and self.config.indents['switch_case_labels'] != "indent"
+
+            if not ignore_switch_case:
+                self.indent_level += 1
             try:
                 return method(self, ctx)
             finally:
-                self.indent_level -= 1 
+                if not ignore_switch_case:
+                    self.indent_level -= 1 
         return wrapper
 
 
@@ -250,9 +254,9 @@ class FormattingVisitor(JavaParserVisitor):
         return sorted(modifiers, key=lambda x: order.index(x) if x in order else len(order))
     
     def _get_indent(self):
-        match self.config.indentation_type:
+        match self.config.indents['type']:
             case "spaces":
-                return " " * (self.indent_level * self.config.indent_size)
+                return " " * (self.indent_level * self.config.indents['size'])
             # may it appear as 8 spaces but it is actually configurable
             # in text editors so it should be as a size of indent_size
             case "tabs":


### PR DESCRIPTION
This pull request includes significant changes to the configuration and handling of indentation settings in both the configuration files and the codebase. The changes ensure consistency and flexibility in the configuration of indentation types and sizes.

### Configuration changes:
* [`.java-format.json`](diffhunk://#diff-da92ad726f052e2a22ead6184520136e374352f3ad7efea4a0d987a6ecaf2942L2-L5): Removed `indent_size` and `indentation_type` settings, and added a new `indents` object to encapsulate indentation settings, including `size`, `type`, and `switch_case_labels`. [[1]](diffhunk://#diff-da92ad726f052e2a22ead6184520136e374352f3ad7efea4a0d987a6ecaf2942L2-L5) [[2]](diffhunk://#diff-da92ad726f052e2a22ead6184520136e374352f3ad7efea4a0d987a6ecaf2942R17-R21)

### Codebase updates:
* [`ConfigClass.py`](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9L12-L15): Updated the `default_config`, `read_config`, and `save_config` methods to use the new `indents` object instead of individual indentation settings. [[1]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9L12-L15) [[2]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9L27-R32) [[3]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9L44-R54) [[4]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9L63-R67)
* [`FormattingVisitor.py`](diffhunk://#diff-bc83f4e09af6532ae36b35f0cb0f48524a2ca1a17548a6c105edee6f065ce70fR193-R200): Modified the `handle_indentation` decorator to account for the new `switch_case_labels` setting and updated the `_get_indent` method to use the new `indents` object for determining indentation type and size. [[1]](diffhunk://#diff-bc83f4e09af6532ae36b35f0cb0f48524a2ca1a17548a6c105edee6f065ce70fR193-R200) [[2]](diffhunk://#diff-bc83f4e09af6532ae36b35f0cb0f48524a2ca1a17548a6c105edee6f065ce70fL253-R259)