### PR TITLE
Implemented bracket alignment on method call + related config mods.

### DIFF
--- a/.java-format.json
+++ b/.java-format.json
@@ -22,6 +22,6 @@
     },
     "aligns" : {
         "after_open_bracket": "align",
-        "parameters_before_align": 1
+        "parameters_before_align": 2
     }
 }

--- a/.java-format.json
+++ b/.java-format.json
@@ -17,7 +17,11 @@
     },
     "indents": {
         "size": 4,
-        "type": "tabs",
+        "type": "spaces",
         "switch_case_labels": "indent"
+    },
+    "aligns" : {
+        "after_open_bracket": "align",
+        "parameters_before_align": 1
     }
 }

--- a/ConfigClass.py
+++ b/ConfigClass.py
@@ -21,15 +21,6 @@ class ConfigClass:
             'parameter': 'camelcase',
             'constant': 'uppercase'
         }
-        """ 
-        "naming_conventions": {
-            "class": "[A-Z][a-zA-Z0-9]*",  
-            "method": "[a-z][a-zA-Z0-9]*",  
-            "variable": "[a-z][a-zA-Z0-9]*",  
-            "parameter": "[a-z][a-zA-Z0-9]*", 
-            "constant": "[A-Z][A-Z0-9_]*" 
-        }
-    """
         self.imports = {
             'order': 'preserve', # 'preserve' or 'sort'
             'merge': False
@@ -38,6 +29,10 @@ class ConfigClass:
             'size': 4,
             'type': 'spaces', # 'spaces' or 'tabs'
             'switch_case_labels': 'indent', # 'indent' or 'no_indent'
+        }
+        self.aligns = {
+            'after_open_bracket': 'align', # false, 'align', 'dont_align', 'always_break', 'block_indent'
+            'parameters_before_align': 1 # How many parameters before breaking if 'after_open_bracket' is 'align' or 'dont_align'
         }
 
     def read_config(self):
@@ -61,6 +56,7 @@ class ConfigClass:
         self.naming_conventions = config_json.get('naming_conventions', self.naming_conventions)
         self.imports = config_json.get('imports', self.imports)
         self.indents = config_json.get('indents', self.indents)
+        self.aligns = config_json.get('aligns', self.aligns)
 
     # Kept for future use
     def save_config(self):
@@ -73,7 +69,8 @@ class ConfigClass:
             'method_modifier_order': self.method_modifier_order,
             'naming_conventions': self.naming_conventions,
             'imports': self.imports,
-            'indents': self.indents
+            'indents': self.indents,
+            'aligns': self.aligns
         }
 
         with open(self.config_path, 'w') as f:

--- a/ConfigClass.py
+++ b/ConfigClass.py
@@ -32,7 +32,7 @@ class ConfigClass:
         }
         self.aligns = {
             'after_open_bracket': 'align', # false, 'align', 'dont_align', 'always_break', 'block_indent'
-            'parameters_before_align': 1 # How many parameters before breaking if 'after_open_bracket' is 'align' or 'dont_align'
+            'parameters_before_align': 2 # How many parameters before breaking if 'after_open_bracket' is 'align' or 'dont_align'
         }
 
     def read_config(self):

--- a/ErrorLogger.py
+++ b/ErrorLogger.py
@@ -13,7 +13,6 @@ class ErrorLogger(JavaParserVisitor):
         class_name = ctx.identifier().getText()
         class_config = self.configs.naming_conventions["class"]
         error = self.check_convention(class_name, class_config)
-        print(class_name)
         if error:
             self.error_log.append("Class name " + error)
 

--- a/UnitTest.py
+++ b/UnitTest.py
@@ -33,6 +33,10 @@ class MockConfigClass:
             "switch_case_labels": "indent"  # or "no_indent"
         }
         self.space_around_operator = True
+        self.aligns = {
+            'after_open_bracket': 'align', # false, 'align', 'dont_align', 'always_break', 'block_indent'
+            'parameters_before_align': 2 # How many parameters before breaking if 'after_open_bracket' is 'align' or 'dont_align'
+        }
 
 @pytest.fixture
 def config():
@@ -813,4 +817,23 @@ def test_variable_declarations(config):
             assert "final double PI=3.14159" in formatted or "PI=3.14159" in formatted.replace(" ", "")
     except AssertionError:
         logger.warning("Variable declarations test failed, but continuing...")
+        raise
+
+def test_align_open_brackets(config):
+    java_code = """
+    public class Test {
+        public void testMethod(int a, int b, int c, int d, int e, int f) {
+            doSomething();
+        }
+    }
+    """
+    
+    formatted = format_java(java_code, config)
+    
+    try:
+        assert "testMethod(int a, int b,\n" in formatted
+        assert "int c, int d,\n" in formatted
+        assert "int e, int f)" in formatted
+    except AssertionError:
+        logger.warning("Align open brackets test failed, but continuing...")
         raise

--- a/test2.java
+++ b/test2.java
@@ -1,0 +1,8 @@
+public class Test2 {
+    public static void main(String[] args) {
+        test(1, 2);
+    }
+    private static void test(int x, int y) {
+        System.out.println("Hello, World!");
+    }
+}

--- a/test2.java
+++ b/test2.java
@@ -1,8 +1,8 @@
 public class Test2 {
     public static void main(String[] args) {
-        test(1, 2);
+        test(1, 2, 4);
     }
-    private static void test(int x, int y) {
+    private static void test(int x, int y, int z) {
         System.out.println("Hello, World!");
     }
 }

--- a/testmain.py
+++ b/testmain.py
@@ -18,9 +18,11 @@ def parse_java_code(file_path):
     parser = JavaParser(tokens)
     tree = parser.compilationUnit()
 
+    #print(tree.toStringTree(recog=parser))
+
     return tree, tokens
 
-tree, tokens = parse_java_code("test.java")
+tree, tokens = parse_java_code("test2.java")
 configs = load_config(".java-format.json")
 
 formatter = FormattingVisitor(tokens, configs)
@@ -30,4 +32,6 @@ errors = errorvisitor.find_errors(tree)
 if errors:
     for error in errors:
         print(error)
-print(formatter.get_formatted_code(tree))
+
+formatted_code = formatter.get_formatted_code(tree)
+print(formatted_code)


### PR DESCRIPTION
This pull request includes several changes to improve code formatting and introduce new configuration options. The most important changes include modifying the indentation settings, adding alignment configurations, and updating the `ConfigClass` and `FormattingVisitor` to support these new configurations.

### Configuration Updates:

* [`.java-format.json`](diffhunk://#diff-da92ad726f052e2a22ead6184520136e374352f3ad7efea4a0d987a6ecaf2942L20-R25): Changed the indentation type from tabs to spaces and added new alignment configurations (`after_open_bracket` and `parameters_before_align`).

* [`ConfigClass.py`](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9L24-L32): Removed the old `naming_conventions` configuration and added new `aligns` configuration in `default_config`, `read_config`, and `save_config` methods. [[1]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9L24-L32) [[2]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9R33-R36) [[3]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9R59) [[4]](diffhunk://#diff-51a8a07858a7c7eabc9656f94409a7832adbdf1171ec7f771973e75c01f077f9L76-R73)

### Visitor Enhancements:

* [`FormattingVisitor.py`](diffhunk://#diff-bc83f4e09af6532ae36b35f0cb0f48524a2ca1a17548a6c105edee6f065ce70fR248-R288): Added a new method `visitMethodCall` to handle the alignment of method call parameters based on the new configuration settings.

### Code Cleanup:

* [`ErrorLogger.py`](diffhunk://#diff-474af3304b708d2b99f385d82c25a9024eaba909158a71eb76c454efde073406L16): Removed a debug print statement from the `visitClassDeclaration` method.

### Test Addition:

* [`test2.java`](diffhunk://#diff-d095ef57e614f50e4a2fc7d162f592353e7f2573958aa8c0d5c4d15d14230d7fR1-R8): Added a new test file to verify the formatting changes.


I just realized that I forgot to push the modified testmain.py lmfao. Anyway!

### What's left to do:

- I still need to handle the *`align`* and *`dont_align`* breaks better. (If the remaining parameters are more than `parameters_before_align`, break again.)
- Testing *`align`* with tabs is still needed.
- Implementing the same mechanism over in the method declaration